### PR TITLE
Typo fix in positive_calories_remained method

### DIFF
--- a/tests/fixtures/fixture_data.py
+++ b/tests/fixtures/fixture_data.py
@@ -40,7 +40,7 @@ def negative_calories_remained():
 @pytest.fixture
 def positive_calories_remained():
     def _positive_calories_remained(limit):
-        return f'Сегодня можно съесть что-нибудь ещё, но c общей калорийностью не более {limit} кКал'
+        return f'Сегодня можно съесть что-нибудь ещё, но с общей калорийностью не более {limit} кКал'
     return _positive_calories_remained
 
 


### PR DESCRIPTION
Typo fix in positive_calories_remained method in tests/fixtures/fixture_data.py

In `Сегодня можно съесть что-нибудь ещё, но с общей калорийностью не более N кКал` sentence a preposition `с` is written in English, while the sentence itself is in Russian, which can cause confusion.